### PR TITLE
Use orb log command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,12 @@
-version: 2.0
+
+orbs:
+  orb: choilmto/orb@0.0.1
+
+version: 2.1
 jobs:
   build:
-    docker:
-      - image: circleci/ruby:2.4.2-jessie-node
-        auth:
-          username: mydockerhub-user
-          password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
+    machine:
+      image: 'ubuntu-1604:201903-01'
     steps:
       - checkout
-      - run: echo "Hello World"
+      - orb/log


### PR DESCRIPTION
![ezgif-7-37f4c34835d0](https://user-images.githubusercontent.com/22378241/95689450-de96c480-0bde-11eb-8abc-3f741136e5f1.png)

Stubbed out build time logs to CircleCI dashboard.