### PR TITLE
Use orb's workflow-collector job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,17 @@
-orbs:
-  orb: choilmto/orb@0.0.1
-
-version: 2.1
 jobs:
   build:
-    machine:
-      image: 'ubuntu-1604:201903-01'
+    docker:
+      - image: cimg/node:14.13.1
     steps:
       - checkout
-      - orb/log
+      - run:
+          command: npm run build
+  
+orbs:
+  orb: choilmto/orb@0.1.0
+version: 2.1
+workflows:
+  build:
+    jobs:
+      - orb/workflow-collector
+      - build

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 [![CircleCI](https://circleci.com/gh/choilmto/orbtoberfest-example.svg?style=shield&circle-token=3d21dcc01ba82647ca2a404bb5152246d07ad526)](https://app.circleci.com/pipelines/github/choilmto/orbtoberfest-example)
 
 The config contains boilerplate for using the [orb](https://circleci.com/developer/orbs/orb/choilmto/orb)
+
+The project contains starter code for a project using next.js.


### PR DESCRIPTION
The environment variables `CIRCLE_TOKEN`, `JOB_HTTP_SOURCE`, and `WORKFLOW_HTTP_SOURCE` have been set through the project settings dashboards.

A specific version of node was used per [best practices](https://circleci.com/docs/2.0/circleci-images/), but if the image without a tag is used, the pipeline may fail with `Error response from daemon: manifest for cimg/node:latest not found`.